### PR TITLE
Remove specification of background white by js

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <link rel="stylesheet" href="style.css"/>
   <title></title>
 </head>
 <body>

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -7,8 +7,6 @@ describe 'Show Top Page' do
   it 'test' do
     visit 'index.html'
     file_path = File.expand_path('./screenshot.jpg')
-    script = %(document.body.style.backgroundColor = "white")
-    page.execute_script(script)
     save_screenshot(file_path, full: true)
     expect(page).to have_content 'click'
     expect(page).to have_css('form > input')

--- a/style.css
+++ b/style.css
@@ -1,0 +1,3 @@
+* {
+  background: #FEFEFE;
+}


### PR DESCRIPTION
CSS で背景色を指定していない場合にpoltergeist のスクリーンショット結果が透過状態になることが判明した

ので、CSS でスタイルを設定してあげて、poltergeist 側でのスクリプト実行による背景色設定のコードを削除！
